### PR TITLE
fix: `instagram-post` - input.username getting overwritten

### DIFF
--- a/instagram-post/INPUT_SCHEMA.json
+++ b/instagram-post/INPUT_SCHEMA.json
@@ -5,9 +5,9 @@
     "schemaVersion": 1,
     "properties": {
         "username": {
-            "title": "Instagram username",
+            "title": "Instagram usernames",
             "type": "array",
-            "description": "Provide a profile URL of the account you want to scrape the posts from.",
+            "description": "Provide names or the profile URLs of the accounts you want to scrape the posts from.",
             "editor": "stringList",
             "prefill": ["apifytech"]
         },

--- a/instagram-post/main.js
+++ b/instagram-post/main.js
@@ -11,8 +11,6 @@ Apify.main(async () => {
     } else {
         console.log("What are you trying to get? It seems you forgot to add any input.")
     }
-    
-    usernames = Array.from(new Set(input.usernames))
 
     let directUrls = [];
     for (const u in usernames) {


### PR DESCRIPTION
`instagram-post`: The current `main.js` function failed to load the URLs and profile names from the `input.username` field (only used `input.usernameS`.)

The name of the field in the `INPUT_SCHEMA.json` is `username`, the actor, therefore, fails when used from the Apify Console.